### PR TITLE
Updates to measure to use more commmonly used time series to extract dt column

### DIFF
--- a/Measures/export_time_series_modelica/measure.rb
+++ b/Measures/export_time_series_modelica/measure.rb
@@ -339,8 +339,8 @@ class ExportTimeSeriesLoadsCSV < OpenStudio::Measure::ReportingMeasure
     ]
 
     # just grab one of the variables to get the date/time stamps
-    ts = sqlFile.timeSeries('RUN PERIOD 1', 'Zone Timestep', 'Cooling:Electricity')
-	#ts = sqlFile.timeSeries('RUN PERIOD 1', 'Hourly', 'Cooling:Electricity')
+    ts = sqlFile.timeSeries('RUN PERIOD 1', 'Zone Timestep', 'Electricity:Facility') ##Updated this to make sure the serires is present 
+	#ts = sqlFile.timeSeries('RUN PERIOD 1', 'Hourly', 'Electricity:Facility')
 	unless ts.empty? 
       ts = ts.first
       dt_base = nil

--- a/Measures/export_time_series_modelica/measure.xml
+++ b/Measures/export_time_series_modelica/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>export_time_series_loads_csv</name>
   <uid>9fcf6116-c2eb-43d6-93f0-e1bdd822f768</uid>
-  <version_id>3a539fd4-3978-4d0f-bd25-a54905fc7306</version_id>
-  <version_modified>20201212T061249Z</version_modified>
+  <version_id>803f1b51-6377-4fba-b410-c9da6d97276c</version_id>
+  <version_modified>20210115T215520Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ExportTimeSeriesLoadsCSV</class_name>
   <display_name>ExportTimeSeriesLoadsCSV</display_name>
@@ -127,6 +127,12 @@
       <checksum>1E8091B8</checksum>
     </file>
     <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>08F470AC</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.0.1</identifier>
@@ -135,13 +141,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>C172F942</checksum>
-    </file>
-    <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>08F470AC</checksum>
+      <checksum>044B0D2A</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
After discussion with Nate about a hiccup arising in the SDK workflow, I revised the Extract Time Series as CSV measure to use the Electricity:Facility data column to extract the date/time stamps, as opposed to another, less commonly used, data column. This was a minor change, and I confirmed that the measure still works as intended. Thanks, Nate, for bringing this up! Who should review this PR? It should be straight forward. Thanks! 

@vtnate @nllong 